### PR TITLE
docs: ajusting git_operation.guide.md

### DIFF
--- a/docs/guides/git_operation.guide.md
+++ b/docs/guides/git_operation.guide.md
@@ -91,15 +91,12 @@ docs/
 ├── sprint-1/
 │   ├── backlog.md
 │   ├── retrospective.md
-│   └── diagrams/
 ├── sprint-2/
 │   ├── backlog.md
 │   ├── retrospective.md
-│   └── diagrams/
 └── sprint-3/
     ├── backlog.md
     ├── retrospective.md
-    └── diagrams/
 ```
 
 ---


### PR DESCRIPTION
O que foi feito?
- Ajuste em uma informação desatualizada do guia

Como testar:
- Mesmo processo, acessar a pasta docs/guides/ e selecionar git_operation.guide

Observações:
- Não se aplica

Issues:
- Não se aplica