### PR TITLE
feat: add customers and leads modules (dtos, repository, service, con…

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,6 +27,7 @@
         "nodemon": "^3.1.14",
         "prisma": "^7.6.0",
         "ts-node": "^10.9.2",
+        "ts-node-dev": "^2.0.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
       }
@@ -1132,6 +1133,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1320,6 +1335,13 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1477,6 +1499,13 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -1665,6 +1694,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/dynamic-dedupe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
+      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -1978,6 +2017,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2087,6 +2133,28 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2098,6 +2166,37 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/gopd": {
@@ -2227,6 +2326,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2253,6 +2364,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -2511,6 +2638,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2680,6 +2830,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2689,6 +2849,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.0",
@@ -3086,6 +3253,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3104,6 +3293,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/router": {
@@ -3353,6 +3556,27 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -3388,6 +3612,26 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3399,6 +3643,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tinyexec": {
@@ -3443,6 +3700,16 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -3485,6 +3752,54 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-node-dev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.1",
+        "dynamic-dedupe": "^0.3.0",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "resolve": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "source-map-support": "^0.5.12",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^10.4.0",
+        "tsconfig": "^7.0.0"
+      },
+      "bin": {
+        "ts-node-dev": "lib/bin.js",
+        "tsnd": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/strip-bom": "^3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
       }
     },
     "node_modules/tsx": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "crm-backend",
   "version": "1.0.0",
-  "type": "module",
   "main": "src/server.ts",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
@@ -33,6 +32,7 @@
     "nodemon": "^3.1.14",
     "prisma": "^7.6.0",
     "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   }

--- a/server/src/middlewares/error.middleware.ts
+++ b/server/src/middlewares/error.middleware.ts
@@ -29,3 +29,36 @@ export class AcessoNaoAutorizadoError extends AppError {
     this.name = 'AcessoNaoAutorizadoError';
   }
 }
+
+/**
+ * Erro para ser usado quando há conflito de dados (ex: CPF duplicado, e-mail já cadastrado).
+ * Mapeia para um status HTTP 409 (Conflict).
+ */
+export class ConflitoDeDadosError extends AppError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflitoDeDadosError';
+  }
+}
+
+/**
+ * Erro para ser usado quando a requisição é inválida (ex: regra de negócio violada).
+ * Mapeia para um status HTTP 400 (Bad Request).
+ */
+export class RequisicaoInvalidaError extends AppError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequisicaoInvalidaError';
+  }
+}
+
+/**
+ * Erro para ser usado quando os dados enviados falham na validação do schema.
+ * Mapeia para um status HTTP 422 (Unprocessable Entity).
+ */
+export class ErroDeValidacaoError extends AppError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ErroDeValidacaoError';
+  }
+}

--- a/server/src/middlewares/validate.middleware.ts
+++ b/server/src/middlewares/validate.middleware.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction } from "express";
+import { ZodType, ZodError } from "zod";
+import { ErroDeValidacaoError } from "./error.middleware";
+
+// ─────────────────────────────────────────────
+// VALIDATE MIDDLEWARE
+// ─────────────────────────────────────────────
+// Middlewares reutilizáveis de validação Zod.
+// Aplicados nas routes antes de chegar no controller —
+// garantem que dados inválidos nunca chegam ao service.
+// ─────────────────────────────────────────────
+
+// Valida e substitui o req.body pelo valor já parseado pelo Zod
+// Usado em endpoints POST, PUT e PATCH
+export function validateBody(schema: ZodType) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Sobrescreve o body com o valor parseado — campos extras são removidos automaticamente
+      req.body = schema.parse(req.body);
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        // Formata todos os erros de validação em uma única mensagem legível
+        // Ex: "name: Nome é obrigatório | cpf: CPF deve conter exatamente 11 dígitos numéricos"
+        const messages = error.issues.map((e) => `${e.path.join(".")}: ${e.message}`);
+        return next(new ErroDeValidacaoError(messages.join(" | ")));
+      }
+      next(error);
+    }
+  };
+}
+
+// Valida e substitui o req.query pelo valor já parseado pelo Zod
+// Usado em endpoints GET com filtros — os transforms do schema convertem string → tipo correto
+export function validateQuery(schema: ZodType) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Cast para any necessário pois o tipo do Express espera Record<string, string>
+      // mas o Zod pode retornar tipos transformados (boolean, number, etc.)
+      req.query = schema.parse(req.query) as any;
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        // Formata todos os erros de validação em uma única mensagem legível
+        const messages = error.issues.map((e) => `${e.path.join(".")}: ${e.message}`);
+        return next(new ErroDeValidacaoError(messages.join(" | ")));
+      }
+      next(error);
+    }
+  };
+}

--- a/server/src/modules/customers/customer.controller.ts
+++ b/server/src/modules/customers/customer.controller.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from "express";
+import { CustomersService } from "./customer.service";
+import {
+  QueryCustomerSchema,
+  CreateCustomerSchema,
+  UpdateCustomerSchema,
+} from "./customer.dtos";
+
+// ─────────────────────────────────────────────
+// CUSTOMERS CONTROLLER
+// ─────────────────────────────────────────────
+
+// Tipo auxiliar para tipar req.params com id obrigatório
+type ParamsWithId = { id: string };
+
+export const CustomersController = {
+  async findAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      // Query params são parseados e transformados pelo schema antes de chegar no service
+      const filters = QueryCustomerSchema.parse(req.query);
+      const customers = await CustomersService.findAll(filters);
+
+      return res.status(200).json({
+        success: true,
+        data: customers,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async findById(req: Request<ParamsWithId>, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      const customer = await CustomersService.findById(id);
+
+      return res.status(200).json({
+        success: true,
+        data: customer,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const data = CreateCustomerSchema.parse(req.body);
+      const customer = await CustomersService.create(data);
+
+      // 201 Created — recurso criado com sucesso
+      return res.status(201).json({
+        success: true,
+        data: customer,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async update(req: Request<ParamsWithId>, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      const data = UpdateCustomerSchema.parse(req.body);
+      const customer = await CustomersService.update(id, data);
+
+      return res.status(200).json({
+        success: true,
+        data: customer,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async softDelete(req: Request<ParamsWithId>, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+
+      // Service cuida da validação — controller apenas repassa e retorna
+      await CustomersService.softDelete(id);
+
+      return res.status(200).json({
+        success: true,
+        message: "Cliente desativado com sucesso.",
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+};

--- a/server/src/modules/customers/customer.dtos.ts
+++ b/server/src/modules/customers/customer.dtos.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+// ─────────────────────────────────────────────
+// CUSTOMER DTOS
+// ─────────────────────────────────────────────
+
+export const CreateCustomerSchema = z.object({
+  // Nome é o único campo obrigatório na criação
+  name: z.string().min(1, "Nome é obrigatório"),
+  email: z.string().email("E-mail inválido").optional(),
+  // CPF opcional, mas quando informado deve ter exatamente 11 dígitos numéricos (sem máscara)
+  cpf: z
+    .string()
+    .regex(/^\d{11}$/, "CPF deve conter exatamente 11 dígitos numéricos")
+    .optional(),
+  phone: z.string().optional(),
+  // team_id opcional pois um customer pode existir sem estar vinculado a um time ainda
+  team_id: z.string().uuid("team_id deve ser um UUID válido").optional(),
+});
+
+export const UpdateCustomerSchema = z.object({
+  // Todos os campos opcionais — atualiza apenas o que for enviado
+  name: z.string().min(1).optional(),
+  email: z.string().email("E-mail inválido").optional(),
+  cpf: z
+    .string()
+    .regex(/^\d{11}$/, "CPF deve conter exatamente 11 dígitos numéricos")
+    .optional(),
+  phone: z.string().optional(),
+  // is_active permite reativar um customer via update
+  is_active: z.boolean().optional(),
+  team_id: z.string().uuid("team_id deve ser um UUID válido").optional(),
+});
+
+// Query params chegam como string na URL — os transforms convertem para os tipos corretos
+export const QueryCustomerSchema = z.object({
+  team_id: z.string().uuid().optional(),
+  // "true" → true, qualquer outro valor → false
+  is_active: z.string().transform((v) => v === "true").optional(),
+  name: z.string().optional(),
+  cpf: z.string().optional(),
+  // Paginação com transform de string para number
+  page: z.string().transform(Number).optional(),
+  limit: z.string().transform(Number).optional(),
+});
+
+export type CreateCustomerDTO = z.infer<typeof CreateCustomerSchema>;
+export type UpdateCustomerDTO = z.infer<typeof UpdateCustomerSchema>;
+export type QueryCustomerDTO = z.infer<typeof QueryCustomerSchema>;

--- a/server/src/modules/customers/customer.repository.ts
+++ b/server/src/modules/customers/customer.repository.ts
@@ -1,0 +1,66 @@
+import { prisma } from '../../config/prisma';import {
+  CreateCustomerDTO,
+  UpdateCustomerDTO,
+  QueryCustomerDTO,
+} from "./customer.dtos";
+
+// ─────────────────────────────────────────────
+// CUSTOMER REPOSITORY
+// ─────────────────────────────────────────────
+
+export const CustomersRepository = {
+  async findAll(filters: QueryCustomerDTO) {
+    const { team_id, is_active, name, cpf, page = 1, limit = 20 } = filters;
+
+    return prisma.customers.findMany({
+      where: {
+        // Spread condicional — só adiciona o filtro se o valor foi informado
+        ...(team_id && { team_id }),
+        // is_active usa !== undefined pois false é um valor válido e deve ser filtrado
+        ...(is_active !== undefined && { is_active }),
+        // Busca por nome case-insensitive (ex: "joao" encontra "João")
+        ...(name && { name: { contains: name, mode: "insensitive" } }),
+        ...(cpf && { cpf }),
+      },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: { created_at: "desc" },
+    });
+  },
+
+  async findById(id: string) {
+    return prisma.customers.findUnique({
+      where: { id },
+      // Inclui leads relacionados para exibir histórico do customer
+      include: { leads: true },
+    });
+  },
+
+  // Método dedicado para checagem de CPF duplicado no service
+  async findByCpf(cpf: string) {
+    return prisma.customers.findUnique({
+      where: { cpf },
+    });
+  },
+
+  async create(data: CreateCustomerDTO) {
+    return prisma.customers.create({
+      data,
+    });
+  },
+
+  async update(id: string, data: UpdateCustomerDTO) {
+    return prisma.customers.update({
+      where: { id },
+      data,
+    });
+  },
+
+  // Soft delete: mantém o registro no banco, apenas desativa o customer
+  async softDelete(id: string) {
+    return prisma.customers.update({
+      where: { id },
+      data: { is_active: false },
+    });
+  },
+};

--- a/server/src/modules/customers/customer.routes.ts
+++ b/server/src/modules/customers/customer.routes.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+import { CustomersController } from "./customer.controller";
+import {
+  CreateCustomerSchema,
+  UpdateCustomerSchema,
+  QueryCustomerSchema,
+} from "./customer.dtos";
+import { validateBody, validateQuery } from "../../middlewares/validate.middleware";
+
+// ─────────────────────────────────────────────
+// CUSTOMER ROUTES
+// ─────────────────────────────────────────────
+
+export const customersRouter = Router();
+
+// ⚠️ TODO: aplicar authMiddleware em todas as rotas na próxima sprint
+// customersRouter.use(authMiddleware);
+
+// Listagem com filtros opcionais via query params
+customersRouter.get(
+  "/",
+  validateQuery(QueryCustomerSchema),
+  CustomersController.findAll
+);
+
+customersRouter.get(
+  "/:id",
+  CustomersController.findById
+);
+
+// validateBody garante que o body está válido antes de chegar no controller
+customersRouter.post(
+  "/",
+  validateBody(CreateCustomerSchema),
+  CustomersController.create
+);
+
+// PUT — atualização completa do recurso
+customersRouter.put(
+  "/:id",
+  validateBody(UpdateCustomerSchema),
+  CustomersController.update
+);
+
+// PATCH — atualização parcial, usa o mesmo schema pois todos os campos já são opcionais
+customersRouter.patch(
+  "/:id",
+  validateBody(UpdateCustomerSchema),
+  CustomersController.update
+);
+
+// DELETE — soft delete, não remove o registro do banco
+customersRouter.delete(
+  "/:id",
+  CustomersController.softDelete
+);

--- a/server/src/modules/customers/customer.service.ts
+++ b/server/src/modules/customers/customer.service.ts
@@ -1,0 +1,79 @@
+import { CustomersRepository } from "./customer.repository";
+import {
+  CreateCustomerDTO,
+  UpdateCustomerDTO,
+  QueryCustomerDTO,
+} from "./customer.dtos";
+import {
+  RecursoNaoEncontradoError,
+  ConflitoDeDadosError,
+  RequisicaoInvalidaError,
+} from "../../middlewares/error.middleware";
+
+// ─────────────────────────────────────────────
+// CUSTOMER SERVICE
+// ─────────────────────────────────────────────
+
+export const CustomersService = {
+  async findAll(filters: QueryCustomerDTO) {
+    return CustomersRepository.findAll(filters);
+  },
+
+  async findById(id: string) {
+    const customer = await CustomersRepository.findById(id);
+
+    if (!customer) {
+      throw new RecursoNaoEncontradoError("Cliente não encontrado.");
+    }
+
+    return customer;
+  },
+
+  async create(data: CreateCustomerDTO) {
+    // CPF é opcional, mas se informado deve ser único no sistema
+    if (data.cpf) {
+      const existing = await CustomersRepository.findByCpf(data.cpf);
+
+      if (existing) {
+        throw new ConflitoDeDadosError("Já existe um cliente cadastrado com esse CPF.");
+      }
+    }
+
+    return CustomersRepository.create(data);
+  },
+
+  async update(id: string, data: UpdateCustomerDTO) {
+    const customer = await CustomersRepository.findById(id);
+
+    if (!customer) {
+      throw new RecursoNaoEncontradoError("Cliente não encontrado.");
+    }
+
+    // Só verifica duplicidade de CPF se um novo CPF foi informado
+    // e é diferente do CPF atual do cliente
+    if (data.cpf && data.cpf !== customer.cpf) {
+      const existing = await CustomersRepository.findByCpf(data.cpf);
+
+      if (existing) {
+        throw new ConflitoDeDadosError("Já existe um cliente cadastrado com esse CPF.");
+      }
+    }
+
+    return CustomersRepository.update(id, data);
+  },
+
+  async softDelete(id: string) {
+    const customer = await CustomersRepository.findById(id);
+
+    if (!customer) {
+      throw new RecursoNaoEncontradoError("Cliente não encontrado.");
+    }
+
+    // Evita operação desnecessária no banco se já estiver inativo
+    if (!customer.is_active) {
+      throw new RequisicaoInvalidaError("Cliente já está inativo.");
+    }
+
+    return CustomersRepository.softDelete(id);
+  },
+};

--- a/server/src/modules/leads/lead.controller.ts
+++ b/server/src/modules/leads/lead.controller.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from "express";
+import { LeadsService } from "./leads.service";
+import {
+  QueryLeadSchema,
+  CreateLeadSchema,
+  UpdateLeadSchema,
+} from "./lead.dtos";
+
+// ─────────────────────────────────────────────
+// LEADS CONTROLLER
+// ─────────────────────────────────────────────
+
+// Tipo auxiliar para tipar req.params com id obrigatório
+type ParamsWithId = { id: string };
+
+export const LeadsController = {
+  async findAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      // Query params são parseados e transformados pelo schema antes de chegar no service
+      const filters = QueryLeadSchema.parse(req.query);
+      const leads = await LeadsService.findAll(filters);
+
+      return res.status(200).json({
+        success: true,
+        data: leads,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async findById(req: Request<ParamsWithId>, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      const lead = await LeadsService.findById(id);
+
+      return res.status(200).json({
+        success: true,
+        data: lead,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const data = CreateLeadSchema.parse(req.body);
+      const lead = await LeadsService.create(data);
+
+      // 201 Created — recurso criado com sucesso
+      return res.status(201).json({
+        success: true,
+        data: lead,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async update(req: Request<ParamsWithId>, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      const data = UpdateLeadSchema.parse(req.body);
+      const lead = await LeadsService.update(id, data);
+
+      return res.status(200).json({
+        success: true,
+        data: lead,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async softDelete(req: Request<ParamsWithId>, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+
+      // Service cuida da validação — controller apenas repassa e retorna
+      await LeadsService.softDelete(id);
+
+      return res.status(200).json({
+        success: true,
+        message: "Lead desativado com sucesso.",
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+};

--- a/server/src/modules/leads/lead.dtos.ts
+++ b/server/src/modules/leads/lead.dtos.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+// ─────────────────────────────────────────────
+// LEADS DTOS
+// ─────────────────────────────────────────────
+
+// Enum centralizado para reutilizar nos schemas de create, update e query
+export const LeadStatusEnum = z.enum([
+  "novo",
+  "em_atendimento",
+  "aguardando",
+  "finalizado",
+  "perdido",
+]);
+
+export const CreateLeadSchema = z.object({
+  source: z.string().optional(),
+  // Status obrigatório na criação — deve ser um dos valores do enum acima
+  status: LeadStatusEnum,
+  vehicle_interest: z.string().optional(),
+  // customer_id obrigatório — o service valida se o customer existe e está ativo
+  customer_id: z.string().uuid("customer_id deve ser um UUID válido"),
+  // team_id obrigatório — o service valida se o team existe (via TeamsRepository do Pedro)
+  team_id: z.string().uuid("team_id deve ser um UUID válido"),
+  // attendant_id opcional — lead pode ser criado sem atendente e atribuído depois
+  attendant_id: z.string().uuid("attendant_id deve ser um UUID válido").optional(),
+});
+
+export const UpdateLeadSchema = z.object({
+  // Todos os campos opcionais — atualiza apenas o que for enviado
+  source: z.string().optional(),
+  status: LeadStatusEnum.optional(),
+  // is_active permite reativar um lead via update
+  is_active: z.boolean().optional(),
+  vehicle_interest: z.string().optional(),
+  attendant_id: z.string().uuid("attendant_id deve ser um UUID válido").optional(),
+});
+
+// Query params chegam como string na URL — os transforms convertem para os tipos corretos
+export const QueryLeadSchema = z.object({
+  team_id: z.string().uuid().optional(),
+  status: LeadStatusEnum.optional(),
+  attendant_id: z.string().uuid().optional(),
+  customer_id: z.string().uuid().optional(),
+  // "true" → true, qualquer outro valor → false
+  is_active: z.string().transform((v) => v === "true").optional(),
+  // Paginação com transform de string para number
+  page: z.string().transform(Number).optional(),
+  limit: z.string().transform(Number).optional(),
+});
+
+export type CreateLeadDTO = z.infer<typeof CreateLeadSchema>;
+export type UpdateLeadDTO = z.infer<typeof UpdateLeadSchema>;
+export type QueryLeadDTO = z.infer<typeof QueryLeadSchema>;

--- a/server/src/modules/leads/lead.repository.ts
+++ b/server/src/modules/leads/lead.repository.ts
@@ -1,0 +1,83 @@
+import { prisma } from '../../config/prisma';
+import {
+  CreateLeadDTO,
+  UpdateLeadDTO,
+  QueryLeadDTO,
+} from "./lead.dtos";
+
+// ─────────────────────────────────────────────
+// LEADS REPOSITORY
+// ─────────────────────────────────────────────
+
+export const LeadsRepository = {
+  async findAll(filters: QueryLeadDTO) {
+    const {
+      team_id,
+      status,
+      attendant_id,
+      customer_id,
+      is_active,
+      page = 1,
+      limit = 20,
+    } = filters;
+
+    return prisma.leads.findMany({
+      where: {
+        // Spread condicional — só adiciona o filtro se o valor foi informado
+        ...(team_id && { team_id }),
+        ...(status && { status }),
+        ...(attendant_id && { attendant_id }),
+        ...(customer_id && { customer_id }),
+        // is_active usa !== undefined pois false é um valor válido e deve ser filtrado
+        ...(is_active !== undefined && { is_active }),
+      },
+      include: {
+        customers: true,
+        // Seleciona apenas campos públicos do attendant — nunca expor password_hash
+        attendant: {
+          select: { id: true, name: true, email: true, role: true },
+        },
+      },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: { created_at: "desc" },
+    });
+  },
+
+  async findById(id: string) {
+    return prisma.leads.findUnique({
+      where: { id },
+      include: {
+        customers: true,
+        teams: true,
+        // Seleciona apenas campos públicos do attendant — nunca expor password_hash
+        attendant: {
+          select: { id: true, name: true, email: true, role: true },
+        },
+        // Inclui negotiations para exibir histórico completo do lead
+        negotiations: true,
+      },
+    });
+  },
+
+  async create(data: CreateLeadDTO) {
+    return prisma.leads.create({
+      data,
+    });
+  },
+
+  async update(id: string, data: UpdateLeadDTO) {
+    return prisma.leads.update({
+      where: { id },
+      data,
+    });
+  },
+
+  // Soft delete: mantém o registro no banco, apenas desativa o lead
+  async softDelete(id: string) {
+    return prisma.leads.update({
+      where: { id },
+      data: { is_active: false },
+    });
+  },
+};

--- a/server/src/modules/leads/lead.routes.ts
+++ b/server/src/modules/leads/lead.routes.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+import { LeadsController } from "./lead.controller";
+import {
+  CreateLeadSchema,
+  UpdateLeadSchema,
+  QueryLeadSchema,
+} from "./lead.dtos";
+import { validateBody, validateQuery } from "../../middlewares/validate.middleware";
+
+// ─────────────────────────────────────────────
+// LEADS ROUTES
+// ─────────────────────────────────────────────
+
+export const leadsRouter = Router();
+
+// ⚠️ TODO: aplicar authMiddleware em todas as rotas na próxima sprint
+// leadsRouter.use(authMiddleware);
+
+// Listagem com filtros opcionais via query params
+leadsRouter.get(
+  "/",
+  validateQuery(QueryLeadSchema),
+  LeadsController.findAll
+);
+
+leadsRouter.get(
+  "/:id",
+  LeadsController.findById
+);
+
+// validateBody garante que o body está válido antes de chegar no controller
+leadsRouter.post(
+  "/",
+  validateBody(CreateLeadSchema),
+  LeadsController.create
+);
+
+// PUT — atualização completa do recurso
+leadsRouter.put(
+  "/:id",
+  validateBody(UpdateLeadSchema),
+  LeadsController.update
+);
+
+// PATCH — atualização parcial, usa o mesmo schema pois todos os campos já são opcionais
+leadsRouter.patch(
+  "/:id",
+  validateBody(UpdateLeadSchema),
+  LeadsController.update
+);
+
+// DELETE — soft delete, não remove o registro do banco
+leadsRouter.delete(
+  "/:id",
+  LeadsController.softDelete
+);

--- a/server/src/modules/leads/lead.service.ts
+++ b/server/src/modules/leads/lead.service.ts
@@ -1,0 +1,75 @@
+import { LeadsRepository } from "./leads.repository";
+import { CustomersRepository } from "../customers/customer.repository";
+import {
+  CreateLeadDTO,
+  UpdateLeadDTO,
+  QueryLeadDTO,
+} from "./lead.dtos";
+import {
+  RecursoNaoEncontradoError,
+  RequisicaoInvalidaError,
+} from "../../middlewares/error.middleware";
+
+// ─────────────────────────────────────────────
+// LEADS SERVICE
+// ─────────────────────────────────────────────
+
+export const LeadsService = {
+  async findAll(filters: QueryLeadDTO) {
+    return LeadsRepository.findAll(filters);
+  },
+
+  async findById(id: string) {
+    const lead = await LeadsRepository.findById(id);
+
+    if (!lead) {
+      throw new RecursoNaoEncontradoError("Lead não encontrado.");
+    }
+
+    return lead;
+  },
+
+  async create(data: CreateLeadDTO) {
+    // Regra de negócio: lead só pode ser criado para um customer ativo
+    const customer = await CustomersRepository.findById(data.customer_id);
+
+    if (!customer) {
+      throw new RecursoNaoEncontradoError("Cliente não encontrado.");
+    }
+
+    if (!customer.is_active) {
+      throw new RequisicaoInvalidaError("Não é possível criar um lead para um cliente inativo.");
+    }
+
+    // ⚠️ TODO: validar se team_id existe e está ativo.
+    // Aguardando TeamsRepository (Pedro) para importar e checar aqui.
+    // Enquanto isso, erros de FK do Prisma são capturados pelo error.middleware.ts.
+
+    return LeadsRepository.create(data);
+  },
+
+  async update(id: string, data: UpdateLeadDTO) {
+    const lead = await LeadsRepository.findById(id);
+
+    if (!lead) {
+      throw new RecursoNaoEncontradoError("Lead não encontrado.");
+    }
+
+    return LeadsRepository.update(id, data);
+  },
+
+  async softDelete(id: string) {
+    const lead = await LeadsRepository.findById(id);
+
+    if (!lead) {
+      throw new RecursoNaoEncontradoError("Lead não encontrado.");
+    }
+
+    // Evita operação desnecessária no banco se já estiver inativo
+    if (!lead.is_active) {
+      throw new RequisicaoInvalidaError("Lead já está inativo.");
+    }
+
+    return LeadsRepository.softDelete(id);
+  },
+};

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,44 +1,26 @@
 {
-  // Visit https://aka.ms/tsconfig to read more about this file
   "compilerOptions": {
-    // File Layout
-    // "rootDir": "./src",
-    // "outDir": "./dist",
+    "rootDir": "./src",
+    "outDir": "./dist",
 
-    // Environment Settings
-    // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
+    "module": "CommonJS",
     "target": "esnext",
     "types": ["node"],
-    // For nodejs:
-    // "lib": ["esnext"],
-    // "types": ["node"],
-    // and npm install -D @types/node
 
-    // Other Outputs
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
 
-    // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
 
-    // Style Options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
-
-    // Recommended Options
     "strict": true,
     "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
-    "skipLibCheck": true,
-  }
+    "skipLibCheck": true
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## O que foi feito
Implementação completa dos módulos Customers e Leads, cobrindo todas as camadas da arquitetura:
- DTOs com validação Zod (customer.dtos.ts / lead.dtos.ts)
- Repository via Prisma singleton (customer.repository.ts / lead.repository.ts)
- Service com regras de negócio (customer.service.ts / lead.service.ts)
- Controller com respostas padronizadas (customer.controller.ts / lead.controller.ts)
- Routes com middleware de validação Zod (customer.routes.ts / lead.routes.ts)

Também foi criado o validate.middleware.ts (middlewares reutilizáveis de validação de body e query).

## Como testar
1. POST /customers — criar cliente com CPF válido (11 dígitos)
2. POST /customers — tentar criar com CPF duplicado (esperado: 409)
3. POST /leads — criar lead com customer ativo
4. POST /leads — tentar criar lead com customer inativo (esperado: 400)
5. DELETE /customers/:id — confirmar soft delete (is_active = false)
6. DELETE /leads/:id — confirmar soft delete (is_active = false)

## Observações
- authMiddleware comentado com TODO — será aplicado na próxima sprint junto com o módulo de Auth 
- Validação de team_id no LeadsService pendente — aguardando TeamsRepository 
- Soft delete mantido para customers e leads
- CPF sem máscara — formatação fica por conta do frontend

## Issues
Closes #35 #36  #38  #39 #40 