### PR TITLE
feat: adds layered architecture of importance

### DIFF
--- a/server/src/modules/importance/importance.controller.ts
+++ b/server/src/modules/importance/importance.controller.ts
@@ -1,0 +1,60 @@
+import type { Request, Response, NextFunction } from "express";
+import { importanceService } from "./importance.service.js";
+import { updateNegotiationImportanceSchema } from "./importance.dto.js";
+
+/**
+ * GET /negotiations/:id/importance
+ * Retorna o importance atual de uma negociação (UC23)
+ */
+async function getImportance(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    if (!id || Array.isArray(id)) {
+      res.status(400).json({ success: false, message: "Negotiation ID not provided." });
+      return;
+    }
+
+    const data = await importanceService.getImportance(id);
+
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * PUT /negotiations/:id/importance
+ * Registra um novo importance para a negociação (UC23 — RN17)
+ */
+async function updateImportance(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    if (!id || Array.isArray(id)) {
+      res.status(400).json({ success: false, message: "Negotiation ID not provided." });
+      return;
+    }
+
+    const parsed = updateNegotiationImportanceSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        message: parsed.error.issues.map((i) => i.message).join(", "),
+      });
+      return;
+    }
+
+    // changedBy virá de req.user.id após integração completa do authMiddleware
+    const changedBy = req.user?.id ?? req.body.userId;
+
+    const data = await importanceService.updateImportance(id, parsed.data.importance, changedBy);
+
+    res.status(201).json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const importanceController = {
+  getImportance,
+  updateImportance,
+};

--- a/server/src/modules/importance/importance.repository.ts
+++ b/server/src/modules/importance/importance.repository.ts
@@ -1,0 +1,27 @@
+import { prisma } from "../../config/prisma.js";
+import type { NegotiationImportance } from "./importance.dto.js";
+
+// Busca o importance mais recente de uma negociação (último registro inserido)
+async function findCurrentByNegotiationId(negotiationId: string) {
+    return await prisma.negotiationImportance.findFirst({
+        where: { negotiation_id: negotiationId },
+        orderBy: { created_at: "desc" },
+        select: { id: true, importance: true, created_at: true },
+    });
+};
+
+// Registra um novo importance para a negociação (RN17)
+async function create(negotiationId: string, importance: NegotiationImportance, changedBy: string) {
+    return await prisma.negotiationImportance.create({
+        data: {
+            negotiation_id: negotiationId,
+            importance,
+            created_by_user_id: changedBy,
+        },
+    });
+};
+
+export const importanceRepository = {
+  findCurrentByNegotiationId,
+  create,
+};

--- a/server/src/modules/importance/importance.routes.ts
+++ b/server/src/modules/importance/importance.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { importanceController } from "./importance.controller.js";
+
+const router = Router({ mergeParams: true });
+
+// mergeParams: true — necessário para acessar :id vindo do router pai (/negotiations/:id/importance)
+
+router.get("/", importanceController.getImportance);
+router.put("/", importanceController.updateImportance);
+
+export const importanceRouter = router;

--- a/server/src/modules/importance/importance.service.ts
+++ b/server/src/modules/importance/importance.service.ts
@@ -1,0 +1,29 @@
+import { importanceRepository } from "./importance.repository.js";
+import { RecursoNaoEncontradoError, BusinessRuleError } from "../../middlewares/error.middleware.js";
+import type { NegotiationImportance } from "./importance.dto.js";
+
+// Retorna o importance atual de uma negociação (registro mais recente)
+async function getImportance(negotiationId: string) {
+  const current = await importanceRepository.findCurrentByNegotiationId(negotiationId);
+  if (!current)
+        throw new RecursoNaoEncontradoError("No importance record found for this negotiation.");
+    return current;
+};
+
+// Registra um novo importance para a negociação (RN17 — pode ser alterado a qualquer momento)
+async function updateImportance(negotiationId: string, importance: NegotiationImportance, changedBy: string) {
+  const current = await importanceRepository.findCurrentByNegotiationId(negotiationId);
+
+  // Garante que o novo valor é diferente do atual
+  if (current?.importance === importance) {
+    throw new BusinessRuleError(
+      `The negotiation importance is already "${importance}".`,
+    );
+  }
+  return await importanceRepository.create(negotiationId, importance, changedBy);
+};
+
+export const importanceService = {
+  getImportance,
+  updateImportance,
+};


### PR DESCRIPTION
## O que foi feito
Implementado módulo de **importance da negociação**, incluindo:
- Controller com endpoints GET e PUT para consulta e atualização
- Service com regras de negócio (validação de mudança de valor)
- Repository para persistência via Prisma
- DTO com validação usando Zod
- Definição de rotas com `mergeParams` para uso do `:id`

## Como testar
1. Fazer uma requisição GET em `/negotiations/:id/importance`
   - Deve retornar o importance atual da negociação
2. Fazer uma requisição PUT em `/negotiations/:id/importance`
   - Body: `{ "importance": "frio" | "morno" | "quente" }`
   - Deve criar um novo registro de importance
3. Testar envio do mesmo valor atual
   - Deve retornar erro de regra de negócio
4. Testar body inválido
   - Deve retornar erro de validação

## Observações
- O campo `changedBy` está temporariamente vindo de `req.user?.id` ou `req.body.userId` até integração completa com auth
- A estratégia adotada foi **append-only** (novo registro a cada alteração)
- Ordenação por `created_at` garante recuperação do valor mais recente
- Validação de não duplicidade de valor implementada no service

## Issue relacionada (se houver)
Closes # (preencher se aplicável)